### PR TITLE
Specify versions in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,8 @@ Imports:
   tidyr (>= 1.1.2),
   plotly (>= 4.10.0),
   dplyr (>= 1.0.2),
-  magrittr
+  magrittr,
+  tidyselect
 Suggests: 
     knitr,
     rmarkdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
   plotly (>= 4.10.0),
   dplyr (>= 1.0.2),
   magrittr,
-  tidyselect
+  tidyselect (>= 1.1.2)
 Suggests: 
     knitr,
     rmarkdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Imports:
   tidyr (>= 1.1.2),
   plotly (>= 4.10.0),
   dplyr (>= 1.0.2),
-  magrittr,
+  magrittr (>=2.0.1),
   tidyselect (>= 1.1.2)
 Suggests: 
     knitr,


### PR DESCRIPTION
`devtools::check()` produces this warning. Adding tidyselect to DESCRIPTION removes the warning. Please verify if a simple tidyselect or we need a version requirement is needed.

```
❯ checking dependencies in R code ... WARNING
  '::' or ':::' import not declared from: 'tidyselect'
```